### PR TITLE
Do not run coveralls when variable is not really set

### DIFF
--- a/recipe/test-coverage.sh
+++ b/recipe/test-coverage.sh
@@ -14,4 +14,4 @@ pip install cpp-coveralls
 
 cd $SRC_DIR/src/libexactreal/
 set +x
-if [ -n "$COVERALLS_REPO_TOKEN" ];then coveralls --gcov `which x86_64-conda_cos6-linux-gnu-gcov` --exclude exact-real/external --gcov-options '\-lrp' -b .; fi
+if [ ${#COVERALLS_REPO_TOKEN} = 33 ];then coveralls --gcov `which x86_64-conda_cos6-linux-gnu-gcov` --exclude exact-real/external --gcov-options '\-lrp' -b .; fi


### PR DESCRIPTION
I do not really understand why the variable is set at all but that's
maybe how secrets work in azure, i.e., they get some non-empty value
when they are missing?