### PR TITLE
Add some implicit conversions

### DIFF
--- a/libexactreal/src/element.cc
+++ b/libexactreal/src/element.cc
@@ -122,11 +122,6 @@ Element<Ring>::Element(const typename Ring::ElementClass& value) : Element(Modul
 }
 
 template <typename Ring>
-Element<Ring>::Element(const RealNumber& value) {
-  throw std::logic_error("not implemented: from RealNumber");
-}
-
-template <typename Ring>
 typename Ring::ElementClass Element<Ring>::operator[](const size i) const {
   return impl->coefficients.at(i);
 }

--- a/libexactreal/src/element.cc
+++ b/libexactreal/src/element.cc
@@ -103,19 +103,19 @@ template <typename Ring>
 template <bool Enabled, std::enable_if_t<Enabled, bool>>
 Element<Ring>::Element(const Element<IntegerRing>& value)
     : impl(spimpl::make_impl<Element<Ring>::Implementation>(
-        Module<Ring>::make(value.module()->basis()),
-        [&](const auto& coefficients) {
-          return std::vector<typename Ring::ElementClass>(coefficients.begin(), coefficients.end());
-        }(value.coefficients()))) {}
+          Module<Ring>::make(value.module()->basis()),
+          [&](const auto& coefficients) {
+            return std::vector<typename Ring::ElementClass>(coefficients.begin(), coefficients.end());
+          }(value.coefficients()))) {}
 
 template <typename Ring>
 template <bool Enabled, std::enable_if_t<Enabled, bool>>
 Element<Ring>::Element(const Element<RationalField>& value)
     : impl(spimpl::make_impl<Element<Ring>::Implementation>(
-        Module<Ring>::make(value.module()->basis()),
-        [&](const auto& coefficients) {
-          return std::vector<typename Ring::ElementClass>(coefficients.begin(), coefficients.end());
-        }(value.coefficients()))) {}
+          Module<Ring>::make(value.module()->basis()),
+          [&](const auto& coefficients) {
+            return std::vector<typename Ring::ElementClass>(coefficients.begin(), coefficients.end());
+          }(value.coefficients()))) {}
 
 template <typename Ring>
 Element<Ring>::Element(const typename Ring::ElementClass& value) : Element(Module<Ring>::make({RealNumber::rational(1)}, Ring(value)), {value}) {
@@ -515,4 +515,4 @@ template Element<NumberField>& Element<NumberField>::operator/=(const mpq_class&
 template Element<NumberField>& Element<NumberField>::operator/=(const eantic::renf_elem_class&);
 template std::vector<mpq_class> Element<NumberField>::coefficients<mpq_class>() const;
 template std::vector<eantic::renf_elem_class> Element<NumberField>::coefficients<eantic::renf_elem_class>() const;
-}
+}  // namespace exactreal

--- a/libexactreal/src/element.cc
+++ b/libexactreal/src/element.cc
@@ -50,7 +50,7 @@ class ElementImplementation {
 
   ElementImplementation(const shared_ptr<const Module<Ring>>& parent, const vector<typename Ring::ElementClass>& coefficients)
       : parent(parent), coefficients(coefficients) {
-    assert(size(coefficients.size()) == parent->rank());
+    assert(static_cast<size>(coefficients.size()) == parent->rank());
   }
 
   shared_ptr<const Module<Ring>> parent;
@@ -96,16 +96,34 @@ template <typename Ring>
 Element<Ring>::Element() : impl(spimpl::make_impl<Element<Ring>::Implementation>()) {}
 
 template <typename Ring>
-Element<Ring>::Element(const shared_ptr<const Module<Ring>>& parent) : impl(spimpl::make_impl<Element<Ring>::Implementation>(parent)) {}
-
-template <typename Ring>
 Element<Ring>::Element(const shared_ptr<const Module<Ring>>& parent, const vector<typename Ring::ElementClass>& coefficients)
     : impl(spimpl::make_impl<Element<Ring>::Implementation>(parent, coefficients)) {}
 
 template <typename Ring>
-Element<Ring>::Element(const shared_ptr<const Module<Ring>>& parent, const size gen)
-    : impl(spimpl::make_impl<Element<Ring>::Implementation>(parent)) {
-  impl->coefficients[numeric_cast<size_t>(gen)] = 1;
+template <bool Enabled, std::enable_if_t<Enabled, bool>>
+Element<Ring>::Element(const Element<IntegerRing>& value)
+    : impl(spimpl::make_impl<Element<Ring>::Implementation>(
+        Module<Ring>::make(value.module()->basis()),
+        [&](const auto& coefficients) {
+          return std::vector<typename Ring::ElementClass>(coefficients.begin(), coefficients.end());
+        }(value.coefficients()))) {}
+
+template <typename Ring>
+template <bool Enabled, std::enable_if_t<Enabled, bool>>
+Element<Ring>::Element(const Element<RationalField>& value)
+    : impl(spimpl::make_impl<Element<Ring>::Implementation>(
+        Module<Ring>::make(value.module()->basis()),
+        [&](const auto& coefficients) {
+          return std::vector<typename Ring::ElementClass>(coefficients.begin(), coefficients.end());
+        }(value.coefficients()))) {}
+
+template <typename Ring>
+Element<Ring>::Element(const typename Ring::ElementClass& value) : Element(Module<Ring>::make({RealNumber::rational(1)}, Ring(value)), {value}) {
+}
+
+template <typename Ring>
+Element<Ring>::Element(const RealNumber& value) {
+  throw std::logic_error("not implemented: from RealNumber");
 }
 
 template <typename Ring>
@@ -392,7 +410,7 @@ Element<Ring>& Element<Ring>::promote(const shared_ptr<const Module<Ring>>& pare
     return *this;
   }
   if (!*this) {
-    return *this = Element(parent);
+    return *this = parent->zero();
   }
   auto& our_gens = impl->parent->basis();
   assert(std::all_of(our_gens.begin(), our_gens.end(), [&](const auto& gen) { return std::find_if(parent->basis().begin(), parent->basis().end(), [&](const auto& ogen) { return *gen == *ogen; }) != parent->basis().end(); }) &&
@@ -467,30 +485,34 @@ ostream& operator<<(ostream& out, const Element<Ring>& self) {
 #include "exact-real/number_field.hpp"
 #include "exact-real/rational_field.hpp"
 
-template class exactreal::Element<IntegerRing>;
-template ostream& exactreal::operator<<<IntegerRing>(ostream&, const Element<IntegerRing>&);
-template Element<IntegerRing>& exactreal::Element<IntegerRing>::operator*=(const int&);
-template Element<IntegerRing>& exactreal::Element<IntegerRing>::operator*=(const mpz_class&);
-template class exactreal::Element<RationalField>;
-template std::vector<typename IntegerRing::ElementClass> exactreal::Element<IntegerRing>::coefficients() const;
-template ostream& exactreal::operator<<<RationalField>(ostream&, const Element<RationalField>&);
-template Element<RationalField>& exactreal::Element<RationalField>::operator*=(const int&);
-template Element<RationalField>& exactreal::Element<RationalField>::operator*=(const mpz_class&);
-template Element<RationalField>& exactreal::Element<RationalField>::operator*=(const mpq_class&);
-template Element<RationalField>& exactreal::Element<RationalField>::operator/=(const int&);
-template Element<RationalField>& exactreal::Element<RationalField>::operator/=(const mpz_class&);
-template Element<RationalField>& exactreal::Element<RationalField>::operator/=(const mpq_class&);
+namespace exactreal {
+template class Element<IntegerRing>;
+template ostream& operator<<<IntegerRing>(ostream&, const Element<IntegerRing>&);
+template Element<IntegerRing>& Element<IntegerRing>::operator*=(const int&);
+template Element<IntegerRing>& Element<IntegerRing>::operator*=(const mpz_class&);
 
-template std::vector<typename RationalField::ElementClass> exactreal::Element<RationalField>::coefficients() const;
-template class exactreal::Element<NumberField>;
-template ostream& exactreal::operator<<<NumberField>(ostream&, const Element<NumberField>&);
-template Element<NumberField>& exactreal::Element<NumberField>::operator*=(const int&);
-template Element<NumberField>& exactreal::Element<NumberField>::operator*=(const mpz_class&);
-template Element<NumberField>& exactreal::Element<NumberField>::operator*=(const mpq_class&);
-template Element<NumberField>& exactreal::Element<NumberField>::operator*=(const eantic::renf_elem_class&);
-template Element<NumberField>& exactreal::Element<NumberField>::operator/=(const int&);
-template Element<NumberField>& exactreal::Element<NumberField>::operator/=(const mpz_class&);
-template Element<NumberField>& exactreal::Element<NumberField>::operator/=(const mpq_class&);
-template Element<NumberField>& exactreal::Element<NumberField>::operator/=(const eantic::renf_elem_class&);
-template std::vector<mpq_class> exactreal::Element<NumberField>::coefficients<mpq_class>() const;
-template std::vector<eantic::renf_elem_class> exactreal::Element<NumberField>::coefficients<eantic::renf_elem_class>() const;
+template class Element<RationalField>;
+template Element<RationalField>::Element(const Element<IntegerRing>&);
+template std::vector<typename IntegerRing::ElementClass> Element<IntegerRing>::coefficients() const;
+template ostream& operator<<<RationalField>(ostream&, const Element<RationalField>&);
+template Element<RationalField>& Element<RationalField>::operator*=(const int&);
+template Element<RationalField>& Element<RationalField>::operator*=(const mpz_class&);
+template Element<RationalField>& Element<RationalField>::operator*=(const mpq_class&);
+template Element<RationalField>& Element<RationalField>::operator/=(const int&);
+template Element<RationalField>& Element<RationalField>::operator/=(const mpz_class&);
+template Element<RationalField>& Element<RationalField>::operator/=(const mpq_class&);
+
+template std::vector<typename RationalField::ElementClass> Element<RationalField>::coefficients() const;
+template class Element<NumberField>;
+template ostream& operator<<<NumberField>(ostream&, const Element<NumberField>&);
+template Element<NumberField>& Element<NumberField>::operator*=(const int&);
+template Element<NumberField>& Element<NumberField>::operator*=(const mpz_class&);
+template Element<NumberField>& Element<NumberField>::operator*=(const mpq_class&);
+template Element<NumberField>& Element<NumberField>::operator*=(const eantic::renf_elem_class&);
+template Element<NumberField>& Element<NumberField>::operator/=(const int&);
+template Element<NumberField>& Element<NumberField>::operator/=(const mpz_class&);
+template Element<NumberField>& Element<NumberField>::operator/=(const mpq_class&);
+template Element<NumberField>& Element<NumberField>::operator/=(const eantic::renf_elem_class&);
+template std::vector<mpq_class> Element<NumberField>::coefficients<mpq_class>() const;
+template std::vector<eantic::renf_elem_class> Element<NumberField>::coefficients<eantic::renf_elem_class>() const;
+}

--- a/libexactreal/src/exact-real/element.hpp
+++ b/libexactreal/src/exact-real/element.hpp
@@ -31,6 +31,8 @@
 
 #include "exact-real/exact-real.hpp"
 #include "exact-real/forward.hpp"
+#include "exact-real/integer_ring.hpp"
+#include "exact-real/rational_field.hpp"
 
 namespace exactreal {
 
@@ -42,18 +44,17 @@ class Element : boost::additive<Element<Ring>>,
                 boost::totally_ordered<Element<Ring>, mpq_class>,
                 boost::totally_ordered<Element<Ring>, mpz_class>,
                 boost::totally_ordered<Element<Ring>, long long>,
-                boost::multiplicative<Element<Ring>, typename Ring::ElementClass>,
-                std::conditional_t<std::is_same_v<typename Ring::ElementClass, mpz_class>, boost::blank,
-                                   std::conditional_t<Ring::isField, boost::multiplicative<Element<Ring>, mpz_class>, boost::multipliable<Element<Ring>, mpz_class>>>,
-                std::conditional_t<std::is_same_v<typename Ring::ElementClass, mpq_class>, boost::blank,
-                                   std::conditional_t<Ring::isField, boost::multiplicative<Element<Ring>, mpq_class>, boost::multipliable<Element<Ring>, mpq_class>>>,
-                std::conditional_t<std::is_same_v<typename Ring::ElementClass, int>, boost::blank,
-                                   std::conditional_t<Ring::isField, boost::multiplicative<Element<Ring>, int>, boost::multipliable<Element<Ring>, int>>> {
+                boost::multiplicative<Element<Ring>, typename Ring::ElementClass> {
  public:
   Element();
-  explicit Element(const std::shared_ptr<const Module<Ring>>& parent);
   Element(const std::shared_ptr<const Module<Ring>>& parent, const std::vector<typename Ring::ElementClass>& coefficients);
-  Element(const std::shared_ptr<const Module<Ring>>& parent, const size gen);
+
+  Element(const typename Ring::ElementClass& value);
+  Element(const RealNumber& gen);
+  template <bool Enabled = !std::is_same_v<Ring, IntegerRing>, std::enable_if_t<Enabled, bool> = true>
+  Element(const Element<IntegerRing>& value);
+  template <bool Enabled = !std::is_same_v<Ring, RationalField> && std::is_convertible_v<mpq_class, typename Ring::ElementClass>, std::enable_if_t<Enabled, bool> = true>
+  Element(const Element<RationalField>& value);
 
   typename Ring::ElementClass operator[](const size) const;
   std::conditional<Ring::isField, mpq_class, mpz_class> operator[](const std::pair<size, size>&) const;
@@ -112,6 +113,20 @@ class Element : boost::additive<Element<Ring>>,
 
 template <typename Ring, typename... Args>
 Element(const std::shared_ptr<const Module<Ring>>&, Args...)->Element<Ring>;
+
+Element(int)->Element<IntegerRing>;
+
+Element(unsigned int)->Element<IntegerRing>;
+
+Element(long)->Element<IntegerRing>;
+
+Element(unsigned long)->Element<IntegerRing>;
+
+Element(const mpz_class&)->Element<IntegerRing>;
+
+Element(const mpq_class&)->Element<RationalField>;
+
+Element(const RealNumber&)->Element<IntegerRing>;
 
 }  // namespace exactreal
 

--- a/libexactreal/src/exact-real/element.hpp
+++ b/libexactreal/src/exact-real/element.hpp
@@ -50,7 +50,6 @@ class Element : boost::additive<Element<Ring>>,
   Element(const std::shared_ptr<const Module<Ring>>& parent, const std::vector<typename Ring::ElementClass>& coefficients);
 
   Element(const typename Ring::ElementClass& value);
-  Element(const RealNumber& gen);
   template <bool Enabled = !std::is_same_v<Ring, IntegerRing>, std::enable_if_t<Enabled, bool> = true>
   Element(const Element<IntegerRing>& value);
   template <bool Enabled = !std::is_same_v<Ring, RationalField> && std::is_convertible_v<mpq_class, typename Ring::ElementClass>, std::enable_if_t<Enabled, bool> = true>

--- a/libexactreal/src/exact-real/integer_ring.hpp
+++ b/libexactreal/src/exact-real/integer_ring.hpp
@@ -30,6 +30,9 @@
 namespace exactreal {
 
 struct IntegerRing : boost::equality_comparable<IntegerRing> {
+  IntegerRing();
+  IntegerRing(const mpz_class&);
+
   typedef mpz_class ElementClass;
   static constexpr bool isField = false;
   static Arb arb(const ElementClass& x, long prec);

--- a/libexactreal/src/exact-real/module.hpp
+++ b/libexactreal/src/exact-real/module.hpp
@@ -47,6 +47,7 @@ class Module : public std::enable_shared_from_this<Module<Ring>>, boost::equalit
 
   const Basis& basis() const;
   Element<Ring> gen(size i) const;
+  Element<Ring> zero() const;
 
   // Return whether this module has the same generators in the same order over the same ring.
   bool operator==(const Module<Ring>& rhs) const;

--- a/libexactreal/src/exact-real/number_field.hpp
+++ b/libexactreal/src/exact-real/number_field.hpp
@@ -34,6 +34,7 @@ class NumberField : boost::equality_comparable<NumberField> {
  public:
   NumberField();
   NumberField(const std::shared_ptr<const eantic::renf_class>&);
+  NumberField(const eantic::renf_elem_class&);
 
   std::shared_ptr<const eantic::renf_class> parameters;
 

--- a/libexactreal/src/exact-real/rational_field.hpp
+++ b/libexactreal/src/exact-real/rational_field.hpp
@@ -30,6 +30,9 @@
 namespace exactreal {
 
 struct RationalField : boost::equality_comparable<RationalField> {
+  RationalField();
+  RationalField(const mpq_class&);
+
   typedef mpq_class ElementClass;
   static constexpr bool isField = true;
   static Arb arb(const ElementClass& x, long prec);

--- a/libexactreal/src/integer_ring.cc
+++ b/libexactreal/src/integer_ring.cc
@@ -22,5 +22,8 @@
 #include "exact-real/arb.hpp"
 
 namespace exactreal {
+IntegerRing::IntegerRing() {}
+IntegerRing::IntegerRing(const mpz_class&) {}
+
 Arb IntegerRing::arb(const ElementClass& x, long) { return Arb(x); }
 }  // namespace exactreal

--- a/libexactreal/src/module.cc
+++ b/libexactreal/src/module.cc
@@ -19,6 +19,7 @@
  *********************************************************************/
 
 #include <e-antic/renfxx.h>
+#include <boost/numeric/conversion/cast.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <set>
@@ -32,6 +33,7 @@
 #include "external/unique-factory/unique_factory.hpp"
 
 using namespace exactreal;
+using boost::numeric_cast;
 using boost::adaptors::transformed;
 using std::is_same_v;
 using std::set;
@@ -101,11 +103,6 @@ vector<shared_ptr<const RealNumber>> const& Module<Ring>::basis() const {
 }
 
 template <typename Ring>
-Element<Ring> Module<Ring>::gen(size i) const {
-  return Element<Ring>(this->shared_from_this(), i);
-}
-
-template <typename Ring>
 const Ring& Module<Ring>::ring() const {
   return impl->parameters;
 }
@@ -157,6 +154,18 @@ bool Module<Ring>::submodule(const Module<Ring>& supermodule) const {
     }
   }
   return true;
+}
+
+template <typename Ring>
+Element<Ring> Module<Ring>::gen(size j) const {
+  std::vector<typename Ring::ElementClass> coefficients(this->rank());
+  coefficients[numeric_cast<size_t>(j)] = 1;
+  return Element(this->shared_from_this(), std::move(coefficients));
+}
+
+template <typename Ring>
+Element<Ring> Module<Ring>::zero() const {
+  return Element(this->shared_from_this(), std::vector<typename Ring::ElementClass>(this->rank()));
 }
 
 template <typename R>

--- a/libexactreal/src/module.cc
+++ b/libexactreal/src/module.cc
@@ -19,8 +19,8 @@
  *********************************************************************/
 
 #include <e-antic/renfxx.h>
-#include <boost/numeric/conversion/cast.hpp>
 #include <boost/algorithm/string/join.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <set>
 

--- a/libexactreal/src/number_field.cc
+++ b/libexactreal/src/number_field.cc
@@ -24,13 +24,15 @@
 #include "exact-real/number_field.hpp"
 
 namespace exactreal {
-Arb NumberField::arb(const ElementClass& x, mp_limb_signed_t prec) { return Arb(x, prec); }
-
-bool NumberField::operator==(const NumberField& rhs) const { return parameters == rhs.parameters; }
+NumberField::NumberField() : NumberField(eantic::renf_class::make()) {}
 
 NumberField::NumberField(const std::shared_ptr<const eantic::renf_class>& parameters) : parameters(parameters) {
   assert(parameters && "number field must not be null");
 }
 
-NumberField::NumberField() : NumberField(eantic::renf_class::make()) {}
+NumberField::NumberField(const eantic::renf_elem_class& value) : NumberField(value.parent()) {}
+
+Arb NumberField::arb(const ElementClass& x, mp_limb_signed_t prec) { return Arb(x, prec); }
+
+bool NumberField::operator==(const NumberField& rhs) const { return parameters == rhs.parameters; }
 }  // namespace exactreal

--- a/libexactreal/src/rational_field.cc
+++ b/libexactreal/src/rational_field.cc
@@ -22,5 +22,8 @@
 #include "exact-real/arb.hpp"
 
 namespace exactreal {
+RationalField::RationalField() {}
+RationalField::RationalField(const mpq_class&) {}
+
 Arb RationalField::arb(const ElementClass& x, prec prec) { return Arb(x, prec); }
 }  // namespace exactreal

--- a/libexactreal/test/cereal.test.cc
+++ b/libexactreal/test/cereal.test.cc
@@ -126,8 +126,8 @@ TYPED_TEST(CerealTest, Module) {
 TYPED_TEST(CerealTest, Element) {
   auto m = Module<TypeParam>::make({RealNumber::rational(1), RealNumber::random()});
 
-  test_serialization(Element(m, 1));
-  test_serialization(Element(m));
+  test_serialization(m->gen(1));
+  test_serialization(m->zero());
   test_serialization(Element<TypeParam>());
 }
 }  // namespace exactreal

--- a/libexactreal/test/element.test.cc
+++ b/libexactreal/test/element.test.cc
@@ -51,7 +51,7 @@ TEST(Element, FromPrimitives) {
   EXPECT_EQ(one + zero, one);
   EXPECT_EQ(quot + zero, quot);
   EXPECT_EQ(quot + one, one + quot);
-  
+
   EXPECT_EQ(x + zero, x);
   EXPECT_EQ(x + one - one, x);
   EXPECT_EQ(x + quot + quot, x + one);


### PR DESCRIPTION
so we do not have to be explicit about the module anymore when writing things such as

```c++
  auto one = Element(1);
  auto zero = Element(0);
  auto quot = Element(mpq_class(1, 2));
```