### PR TITLE
Make pyexactreal tests work when another version of exact-real is ins…

### DIFF
--- a/pyexactreal/src/pyexactreal/cppyy_exactreal.py
+++ b/pyexactreal/src/pyexactreal/cppyy_exactreal.py
@@ -278,10 +278,8 @@ def enable_cereal(proxy, name):
 
 cppyy.py.add_pythonization(enable_cereal, "exactreal")
 
-
-for path in os.environ.get('PYEXACTREAL_INCLUDE','').split(':'):
-    if path: cppyy.add_include_path(path)
-
+# Set EXTRA_CLING_ARGS="-I /usr/include" or wherever exact-real/cppyy.hpp can
+# be resolved if the following line fails to find the header file.
 cppyy.add_include_path(os.path.join(os.path.dirname(__file__), 'include'))
 
 cppyy.include("exact-real/cppyy.hpp")

--- a/pyexactreal/test/Makefile.am
+++ b/pyexactreal/test/Makefile.am
@@ -19,7 +19,7 @@ BUILT_SOURCES = test-env.sh python-doctest.sh sage-doctest.sh
 EXTRA_DIST += test-env.sh.in python-doctest.sh.in sage-doctest.sh.in
 CLEANFILES = test-env.sh python-doctest.sh sage-doctest.sh
 $(builddir)/test-env.sh: $(srcdir)/test-env.sh.in Makefile
-	sed -e 's,[@]srcdir[@],$(srcdir),g' -e 's,[@]builddir[@],$(builddir),g' -e 's,[@]pythondir[@],$(pythondir),g' < $< > $@
+	sed -e 's,[@]abs_srcdir[@],$(abs_srcdir),g' -e 's,[@]abs_builddir[@],$(abs_builddir),g' -e 's,[@]pythondir[@],$(pythondir),g' < $< > $@
 $(builddir)/python-doctest.sh: $(srcdir)/python-doctest.sh.in Makefile
 	sed -e 's,[@]srcdir[@],$(srcdir),g' -e 's,[@]builddir[@],$(builddir),g' < $< > $@
 	chmod +x $@

--- a/pyexactreal/test/test-env.sh.in
+++ b/pyexactreal/test/test-env.sh.in
@@ -2,6 +2,6 @@
 
 # Resolve #include <exact-real/*.hpp> relative to libexactreal/ in the source tree and
 # resolve #include "exact-real.hpp" relative to libexactreal/exact-real in the build tree.
-export PYEXACTREAL_INCLUDE="@srcdir@/../../libexactreal:@builddir@/../../libexactreal/exact-real"
-export LD_LIBRARY_PATH="@builddir@/../../libexactreal/src/.libs/"
-export PYTHONPATH="@srcdir@/../src/:@pythondir@"
+export EXTRA_CLING_ARGS="-I@abs_srcdir@/../../libexactreal -I@abs_builddir@/../../libexactreal/exact-real $EXTRA_CLING_ARGS"
+export LD_LIBRARY_PATH="@abs_builddir@/../../libexactreal/src/.libs/:$LD_LIBRARY_PATH"
+export PYTHONPATH="@abs_srcdir@/../src/:@pythondir@"


### PR DESCRIPTION
…talled

Before, the locally installed version would have given precedence

Fixes #85.