### PR TITLE
drop eantic fmpq support

### DIFF
--- a/.ci_support/linux_benchmark.yaml
+++ b/.ci_support/linux_benchmark.yaml
@@ -3,9 +3,9 @@ _python:
 action:
 - benchmark
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:

--- a/.ci_support/linux_coverage.yaml
+++ b/.ci_support/linux_coverage.yaml
@@ -3,9 +3,9 @@ _python:
 action:
 - coverage
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:

--- a/.ci_support/linux_release.yaml
+++ b/.ci_support/linux_release.yaml
@@ -7,9 +7,9 @@ action:
 - release
 - release
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:

--- a/.ci_support/linux_style.yaml
+++ b/.ci_support/linux_style.yaml
@@ -3,9 +3,9 @@ _python:
 action:
 - style
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:

--- a/.ci_support/linux_test36.yaml
+++ b/.ci_support/linux_test36.yaml
@@ -3,9 +3,9 @@ _python:
 action:
 - test
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:

--- a/.ci_support/linux_test37.yaml
+++ b/.ci_support/linux_test37.yaml
@@ -3,9 +3,9 @@ _python:
 action:
 - test
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:

--- a/.ci_support/migrations/boost172.yaml
+++ b/.ci_support/migrations/boost172.yaml
@@ -1,0 +1,12 @@
+migrator_ts: 1582183745
+__migrator:
+  kind:
+    version
+  migration_number:
+    2
+  build_number:
+    1
+boost:
+  - 1.72
+boost_cpp:
+  - 1.72

--- a/libexactreal/src/arb.cc
+++ b/libexactreal/src/arb.cc
@@ -89,13 +89,9 @@ Arb::Arb(const mpz_class& value) noexcept : Arb() {
 Arb::Arb(const std::string& value, const prec precision) : Arb() { arb_set_str(arb_t(), value.c_str(), precision); }
 
 Arb::Arb(const renf_elem_class& renf, const mp_limb_signed_t precision) noexcept : Arb() {
-  if (renf.is_fmpq()) {
-    arb_set_fmpq(arb_t(), renf.fmpq_t(), precision);
-  } else {
-    renf_refine_embedding(renf.parent()->renf_t(), precision);
-    renf_elem_set_evaluation(renf.renf_elem_t(), renf.parent()->renf_t(), precision);
-    arb_set(arb_t(), renf.renf_elem_t()->emb);
-  }
+  renf_refine_embedding(renf.parent()->renf_t(), precision);
+  renf_elem_set_evaluation(renf.renf_elem_t(), renf.parent()->renf_t(), precision);
+  arb_set(arb_t(), renf.renf_elem_t()->emb);
 }
 
 Arb::~Arb() noexcept { arb_clear(arb_t()); }

--- a/libexactreal/src/arb.cc
+++ b/libexactreal/src/arb.cc
@@ -89,8 +89,8 @@ Arb::Arb(const mpz_class& value) noexcept : Arb() {
 Arb::Arb(const std::string& value, const prec precision) : Arb() { arb_set_str(arb_t(), value.c_str(), precision); }
 
 Arb::Arb(const renf_elem_class& renf, const mp_limb_signed_t precision) noexcept : Arb() {
-  renf_refine_embedding(renf.parent()->renf_t(), precision);
-  renf_elem_set_evaluation(renf.renf_elem_t(), renf.parent()->renf_t(), precision);
+  renf_refine_embedding(renf.parent().renf_t(), precision);
+  renf_elem_set_evaluation(renf.renf_elem_t(), renf.parent().renf_t(), precision);
   arb_set(arb_t(), renf.renf_elem_t()->emb);
 }
 

--- a/libexactreal/src/number_field.cc
+++ b/libexactreal/src/number_field.cc
@@ -30,7 +30,7 @@ NumberField::NumberField(const std::shared_ptr<const eantic::renf_class>& parame
   // parameters might contain a null pointer if this is the rational field
 }
 
-NumberField::NumberField(const eantic::renf_elem_class& value) : NumberField(value.parent()) {}
+NumberField::NumberField(const eantic::renf_elem_class& value) : NumberField(value.parent().shared_from_this()) {}
 
 NumberField NumberField::compositum(const NumberField& lhs, const NumberField& rhs) {
   if (lhs == rhs) return lhs;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
   host:
 {%- if libexactreal_requirements %}
     - boost-cpp
-    - e-antic >=1.0a master_1110
+    - e-antic >=1.0a master_1136
     - arb
     - gmp
     - gmpxxll


### PR DESCRIPTION
since renf_elem_class is now always a renf_elem and never an fmpq, see https://github.com/videlec/e-antic/pull/118

fixes #104.