### PR TITLE
Speed up element arithmetic

### DIFF
--- a/libexactreal/benchmark/element.benchmark.cc
+++ b/libexactreal/benchmark/element.benchmark.cc
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <memory>
 
+#include "../exact-real/arb.hpp"
 #include "../exact-real/element.hpp"
 #include "../exact-real/integer_ring.hpp"
 #include "../exact-real/module.hpp"
@@ -35,7 +36,7 @@ namespace exactreal::test {
 template <typename Ring>
 class ElementBenchmark : public benchmark::Fixture {
   typename Ring::ElementClass coefficient() {
-    return rand() % 1024;
+    return rand() % 1024 + 1;
   }
 
   Element<Ring> monomial(std::vector<long> degrees, const std::vector<std::shared_ptr<const RealNumber>>& gens) {
@@ -83,6 +84,22 @@ class ElementBenchmark : public benchmark::Fixture {
   }
 
  public:
+  void addition(benchmark::State& state) {
+    const auto [lhs, rhs] = elements(state);
+
+    for (auto _ : state) {
+      benchmark::DoNotOptimize(lhs + rhs);
+    }
+  }
+
+  void multiplication(benchmark::State& state) {
+    const auto [lhs, rhs] = elements(state);
+
+    for (auto _ : state) {
+      benchmark::DoNotOptimize(lhs * rhs);
+    }
+  }
+
   void truediv(benchmark::State& state) {
     const auto [lhs, rhs] = elements(state);
 
@@ -102,7 +119,16 @@ class ElementBenchmark : public benchmark::Fixture {
     const auto divisor = rhs;
 
     for (auto _ : state) {
-      dividend.floordiv(divisor);
+      benchmark::DoNotOptimize(dividend.floordiv(divisor));
+    }
+  }
+
+  void arb(benchmark::State& state) {
+    const auto [element, __] = elements(state);
+    (void)__;
+
+    for (auto _ : state) {
+      benchmark::DoNotOptimize(element.arb(exactreal::ARB_PRECISION_FAST));
     }
   }
 
@@ -117,6 +143,30 @@ class ElementBenchmark : public benchmark::Fixture {
     b->Args({2, 3, 4, 1, 2});
   }
 };
+
+BENCHMARK_TEMPLATE_DEFINE_F(ElementBenchmark, addition_Z, IntegerRing)
+(benchmark::State& state) { addition(state); }
+BENCHMARK_REGISTER_F(ElementBenchmark, addition_Z)->Apply(ElementBenchmark<IntegerRing>::BenchmarkedDegrees);
+
+BENCHMARK_TEMPLATE_DEFINE_F(ElementBenchmark, addition_Q, RationalField)
+(benchmark::State& state) { addition(state); }
+BENCHMARK_REGISTER_F(ElementBenchmark, addition_Q)->Apply(ElementBenchmark<RationalField>::BenchmarkedDegrees);
+
+BENCHMARK_TEMPLATE_DEFINE_F(ElementBenchmark, addition_K, NumberField)
+(benchmark::State& state) { addition(state); }
+BENCHMARK_REGISTER_F(ElementBenchmark, addition_K)->Apply(ElementBenchmark<NumberField>::BenchmarkedDegrees);
+
+BENCHMARK_TEMPLATE_DEFINE_F(ElementBenchmark, multiplication_Z, IntegerRing)
+(benchmark::State& state) { multiplication(state); }
+BENCHMARK_REGISTER_F(ElementBenchmark, multiplication_Z)->Apply(ElementBenchmark<IntegerRing>::BenchmarkedDegrees);
+
+BENCHMARK_TEMPLATE_DEFINE_F(ElementBenchmark, multiplication_Q, RationalField)
+(benchmark::State& state) { multiplication(state); }
+BENCHMARK_REGISTER_F(ElementBenchmark, multiplication_Q)->Apply(ElementBenchmark<RationalField>::BenchmarkedDegrees);
+
+BENCHMARK_TEMPLATE_DEFINE_F(ElementBenchmark, multiplication_K, NumberField)
+(benchmark::State& state) { multiplication(state); }
+BENCHMARK_REGISTER_F(ElementBenchmark, multiplication_K)->Apply(ElementBenchmark<NumberField>::BenchmarkedDegrees);
 
 BENCHMARK_TEMPLATE_DEFINE_F(ElementBenchmark, truediv_Z, IntegerRing)
 (benchmark::State& state) { truediv(state); }
@@ -141,5 +191,17 @@ BENCHMARK_REGISTER_F(ElementBenchmark, floordiv_Q)->Apply(ElementBenchmark<Ratio
 BENCHMARK_TEMPLATE_DEFINE_F(ElementBenchmark, floordiv_K, NumberField)
 (benchmark::State& state) { floordiv(state); }
 BENCHMARK_REGISTER_F(ElementBenchmark, floordiv_K)->Apply(ElementBenchmark<NumberField>::BenchmarkedDegrees);
+
+BENCHMARK_TEMPLATE_DEFINE_F(ElementBenchmark, arb_Z, IntegerRing)
+(benchmark::State& state) { arb(state); }
+BENCHMARK_REGISTER_F(ElementBenchmark, arb_Z)->Apply(ElementBenchmark<IntegerRing>::BenchmarkedDegrees);
+
+BENCHMARK_TEMPLATE_DEFINE_F(ElementBenchmark, arb_Q, RationalField)
+(benchmark::State& state) { arb(state); }
+BENCHMARK_REGISTER_F(ElementBenchmark, arb_Q)->Apply(ElementBenchmark<RationalField>::BenchmarkedDegrees);
+
+BENCHMARK_TEMPLATE_DEFINE_F(ElementBenchmark, arb_K, NumberField)
+(benchmark::State& state) { arb(state); }
+BENCHMARK_REGISTER_F(ElementBenchmark, arb_K)->Apply(ElementBenchmark<NumberField>::BenchmarkedDegrees);
 
 }  // namespace exactreal::test

--- a/libexactreal/src/Makefile.am
+++ b/libexactreal/src/Makefile.am
@@ -24,22 +24,26 @@ EXTRA_libexactreal_la_DEPENDENCIES = $(srcdir)/libexactreal.map
 endif
 
 nobase_pkginclude_HEADERS =                                  \
-    ../exact-real/real_number.hpp                            \
+    ../exact-real/arb.hpp                                    \
+    ../exact-real/arf.hpp                                    \
+    ../exact-real/cereal.hpp                                 \
+    ../exact-real/cppyy.hpp                                  \
     ../exact-real/element.hpp                                \
-    ../exact-real/module.hpp                                 \
+    ../exact-real/external/spimpl/spimpl.h                   \
+    ../exact-real/forward.hpp                                \
     ../exact-real/integer_ring.hpp                           \
-    ../exact-real/rational_field.hpp                         \
+    ../exact-real/module.hpp                                 \
     ../exact-real/number_field.hpp                           \
     ../exact-real/number_field_ideal.hpp                     \
-    ../exact-real/arf.hpp                                    \
-    ../exact-real/arb.hpp                                    \
-    ../exact-real/forward.hpp                                \
+    ../exact-real/rational_field.hpp                         \
+    ../exact-real/real_number.hpp                            \
+    ../exact-real/seed.hpp                                   \
+    ../exact-real/yap/arb.hpp                                \
     ../exact-real/yap/arb_assign_transformation.hpp          \
     ../exact-real/yap/arb_expr.hpp                           \
-    ../exact-real/yap/arb.hpp                                \
+    ../exact-real/yap/arf.hpp                                \
     ../exact-real/yap/arf_assign_transformation.hpp          \
     ../exact-real/yap/arf_expr.hpp                           \
-    ../exact-real/yap/arf.hpp                                \
     ../exact-real/yap/assign_transformation.hpp              \
     ../exact-real/yap/forward.hpp                            \
     ../exact-real/yap/params_transformation.hpp              \
@@ -47,16 +51,13 @@ nobase_pkginclude_HEADERS =                                  \
     ../exact-real/yap/prec_transformation.hpp                \
     ../exact-real/yap/round_expr.hpp                         \
     ../exact-real/yap/round_transformation.hpp               \
-    ../exact-real/yap/terminal.hpp                           \
-    ../exact-real/external/spimpl/spimpl.h                   \
-    ../exact-real/cereal.hpp                                 \
-    ../exact-real/seed.hpp                                   \
-    ../exact-real/cppyy.hpp
+    ../exact-real/yap/terminal.hpp
 
 noinst_HEADERS =                                          \
-    external/unique-factory/unique_factory.hpp            \
-    external/hash-combine/hash.hpp                        \
     external/gmpxxll/gmpxxll/mpz_class.hpp                \
+    external/hash-combine/hash.hpp                        \
+    external/unique-factory/unique_factory.hpp            \
+    impl/real_number_base.hpp                             \
     util/assert.ipp
 
 $(builddir)/../exact-real/exact-real.hpp: $(srcdir)/../exact-real/exact-real.hpp.in Makefile

--- a/libexactreal/src/constrained_random_real_number.cc
+++ b/libexactreal/src/constrained_random_real_number.cc
@@ -36,11 +36,11 @@
 #include "../exact-real/yap/arf.hpp"
 #include "external/hash-combine/hash.hpp"
 #include "external/unique-factory/unique_factory.hpp"
+#include "impl/real_number_base.hpp"
 
 using namespace exactreal;
 using boost::lexical_cast;
 using std::isfinite;
-using std::make_shared;
 using std::nextafter;
 using std::numeric_limits;
 using std::ostream;
@@ -50,11 +50,11 @@ using std::string;
 namespace {
 
 // A random real number in [a, b]
-class ConstrainedRandomRealNumber final : public RealNumber {
+class ConstrainedRandomRealNumber final : public RealNumberBase {
  public:
   ConstrainedRandomRealNumber(const Arf& initial, long e, const shared_ptr<const RealNumber>& inner) : initial(initial), e(e), inner(inner) {}
 
-  virtual Arf arf(long prec) const override {
+  virtual Arf arf_(long prec) const override {
     if (prec < 1) {
       prec = 0;
     }

--- a/libexactreal/src/impl/real_number_base.hpp
+++ b/libexactreal/src/impl/real_number_base.hpp
@@ -1,0 +1,45 @@
+/**********************************************************************
+ *  This file is part of exact-real.
+ *
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  exact-real is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  exact-real is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with exact-real. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBEXACTREAL_REAL_NUMBER_BASE_HPP
+#define LIBEXACTREAL_REAL_NUMBER_BASE_HPP
+
+#include <unordered_map>
+#include <vector>
+
+#include "../../exact-real/arf.hpp"
+#include "../../exact-real/real_number.hpp"
+
+namespace exactreal {
+
+class RealNumberBase : public RealNumber {
+ public:
+  virtual Arf arf(long prec) const final override;
+  virtual Arf arf_(long prec) const = 0;
+
+ private:
+  mutable std::optional<Arf> arf54;
+  mutable std::optional<Arf> arf64;
+  mutable std::unordered_map<long, Arf> large;
+};
+
+}  // namespace exactreal
+
+#endif

--- a/libexactreal/src/random_real_number.cc
+++ b/libexactreal/src/random_real_number.cc
@@ -32,10 +32,10 @@
 #include "../exact-real/real_number.hpp"
 #include "../exact-real/seed.hpp"
 #include "external/unique-factory/unique_factory.hpp"
+#include "impl/real_number_base.hpp"
 
 using namespace exactreal;
 using boost::random::rand48;
-using std::make_shared;
 using std::optional;
 using std::ostream;
 using std::shared_ptr;
@@ -45,14 +45,14 @@ using std::stringstream;
 namespace {
 
 // A random real number in [0, 1]
-class RandomRealNumber final : public RealNumber {
+class RandomRealNumber final : public RealNumberBase {
  public:
   RandomRealNumber(unsigned int seed) : seed(seed) {}
 
   // Creates a random Arf from digits in base 2.
   // We could speed this up by caching numbers to some precision but let's wait
   // with this until this shows up in the profiler…
-  virtual Arf arf(long prec) const override {
+  virtual Arf arf_(long prec) const override {
     if (prec < 1) {
       prec = 0;
     }

--- a/libexactreal/src/rational_real_number.cc
+++ b/libexactreal/src/rational_real_number.cc
@@ -27,21 +27,23 @@
 #include "../exact-real/real_number.hpp"
 #include "../exact-real/yap/arf.hpp"
 #include "external/unique-factory/unique_factory.hpp"
+#include "impl/real_number_base.hpp"
 
 using namespace exactreal;
-using std::make_shared;
 using std::ostream;
 using std::shared_ptr;
 
 namespace {
 
 // An exact rational number
-class RationalRealNumber final : public RealNumber {
+class RationalRealNumber final : public RealNumberBase {
  public:
   RationalRealNumber() : RationalRealNumber(0) {}
   explicit RationalRealNumber(const mpq_class& value) : value(value) {}
 
-  virtual Arf arf(long prec) const override {
+  virtual Arf arf_(long prec) const override {
+    if (prec == 0)
+      prec = 1;
     return (Arf(value.get_num(), 0) / Arf(value.get_den(), 0))(prec, Arf::Round::NEAR);
   }
 

--- a/libexactreal/src/real_number_product.cc
+++ b/libexactreal/src/real_number_product.cc
@@ -31,14 +31,13 @@
 #include "../exact-real/yap/arf.hpp"
 #include "external/hash-combine/hash.hpp"
 #include "external/unique-factory/unique_factory.hpp"
+#include "impl/real_number_base.hpp"
 #include "util/assert.ipp"
 
 using namespace exactreal;
-using std::make_shared;
 using std::map;
 using std::optional;
 using std::shared_ptr;
-using std::vector;
 
 using Factors = map<shared_ptr<const RealNumber>, int>;
 
@@ -60,7 +59,7 @@ auto& factory() {
 }
 
 // A product of transcendental reals
-class RealNumberProduct final : public RealNumber {
+class RealNumberProduct final : public RealNumberBase {
  public:
   explicit RealNumberProduct(const Factors& factors) : factors(factors) {
     ASSERT(std::all_of(begin(factors), end(factors), [](auto& factor) { return factor.second >= 1; }), "factors must appear at least once");
@@ -125,7 +124,7 @@ class RealNumberProduct final : public RealNumber {
     return factory().get(quotient, [&]() { return new RealNumberProduct(quotient); });
   }
 
-  Arf arf(long prec) const override {
+  Arf arf_(long prec) const override {
     // We naively compute the product of all the factors, i.e., we do
     // nothing smart about repeated factors.
     // The following analysis could certainly be done much more sharply but

--- a/news/arfcache.rst
+++ b/news/arfcache.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* cache arf conversions to speed up arithmetic (in particular with multiple generators)


### PR DESCRIPTION
by caching the RealNumber Arf conversion

```
                                                               Before     After
ElementBenchmark<IntegerRing>/addition_Z/0                        456 ns      456 ns
ElementBenchmark<IntegerRing>/addition_Z/1/1/1                    455 ns      455 ns
ElementBenchmark<IntegerRing>/addition_Z/2/1/0/0/1               2173 ns     2262 ns
ElementBenchmark<IntegerRing>/addition_Z/2/3/4/1/2               3882 ns     4001 ns
ElementBenchmark<RationalField>/addition_Q/0                      745 ns      749 ns
ElementBenchmark<RationalField>/addition_Q/1/1/1                  744 ns      749 ns
ElementBenchmark<RationalField>/addition_Q/2/1/0/0/1             3847 ns     4058 ns
ElementBenchmark<RationalField>/addition_Q/2/3/4/1/2             8704 ns     8899 ns
ElementBenchmark<NumberField>/addition_K/0                        318 ns      314 ns
ElementBenchmark<NumberField>/addition_K/1/1/1                    318 ns      314 ns
ElementBenchmark<NumberField>/addition_K/2/1/0/0/1               1862 ns     1656 ns
ElementBenchmark<NumberField>/addition_K/2/3/4/1/2               3031 ns     2523 ns
ElementBenchmark<IntegerRing>/multiplication_Z/0                 2245 ns     1799 ns
ElementBenchmark<IntegerRing>/multiplication_Z/1/1/1             2379 ns     1798 ns
ElementBenchmark<IntegerRing>/multiplication_Z/2/1/0/0/1         8357 ns     4098 ns
ElementBenchmark<IntegerRing>/multiplication_Z/2/3/4/1/2       308111 ns    23845 ns
ElementBenchmark<RationalField>/multiplication_Q/0               3646 ns     3051 ns
ElementBenchmark<RationalField>/multiplication_Q/1/1/1           3604 ns     3120 ns
ElementBenchmark<RationalField>/multiplication_Q/2/1/0/0/1      10942 ns     6817 ns
ElementBenchmark<RationalField>/multiplication_Q/2/3/4/1/2     330521 ns    36949 ns
ElementBenchmark<NumberField>/multiplication_K/0                 2290 ns     1837 ns
ElementBenchmark<NumberField>/multiplication_K/1/1/1             2239 ns     1834 ns
ElementBenchmark<NumberField>/multiplication_K/2/1/0/0/1         7748 ns     4111 ns
ElementBenchmark<NumberField>/multiplication_K/2/3/4/1/2       302580 ns    24447 ns
ElementBenchmark<IntegerRing>/truediv_Z/0                       11516 ns    10321 ns
ElementBenchmark<IntegerRing>/truediv_Z/1/1/1                   11599 ns    10407 ns
ElementBenchmark<IntegerRing>/truediv_Z/2/1/0/0/1               19527 ns    14830 ns
ElementBenchmark<IntegerRing>/truediv_Z/2/3/4/1/2             2923067 ns   176478 ns
ElementBenchmark<RationalField>/truediv_Q/0                     15024 ns    14329 ns
ElementBenchmark<RationalField>/truediv_Q/1/1/1                 15477 ns    14169 ns
ElementBenchmark<RationalField>/truediv_Q/2/1/0/0/1             27868 ns    22729 ns
ElementBenchmark<RationalField>/truediv_Q/2/3/4/1/2           3134787 ns   323036 ns
ElementBenchmark<NumberField>/truediv_K/0                       12185 ns    10763 ns
ElementBenchmark<NumberField>/truediv_K/1/1/1                   12175 ns    10839 ns
ElementBenchmark<NumberField>/truediv_K/2/1/0/0/1               20897 ns    14649 ns
ElementBenchmark<NumberField>/truediv_K/2/3/4/1/2             3039940 ns   170837 ns
ElementBenchmark<IntegerRing>/floordiv_Z/0                      13849 ns    12084 ns
ElementBenchmark<IntegerRing>/floordiv_Z/1/1/1                  13709 ns    12079 ns
ElementBenchmark<IntegerRing>/floordiv_Z/2/1/0/0/1              21988 ns    16664 ns
ElementBenchmark<IntegerRing>/floordiv_Z/2/3/4/1/2            3636616 ns   199936 ns
ElementBenchmark<RationalField>/floordiv_Q/0                    17103 ns    15819 ns
ElementBenchmark<RationalField>/floordiv_Q/1/1/1                17262 ns    15932 ns
ElementBenchmark<RationalField>/floordiv_Q/2/1/0/0/1            29566 ns    24474 ns
ElementBenchmark<RationalField>/floordiv_Q/2/3/4/1/2          3731512 ns   343992 ns
ElementBenchmark<NumberField>/floordiv_K/0                      14322 ns    12864 ns
ElementBenchmark<NumberField>/floordiv_K/1/1/1                  14325 ns    12926 ns
ElementBenchmark<NumberField>/floordiv_K/2/1/0/0/1              23033 ns    16809 ns
ElementBenchmark<NumberField>/floordiv_K/2/3/4/1/2            3630046 ns   184111 ns
ElementBenchmark<IntegerRing>/arb_Z/0                            2346 ns     1138 ns
ElementBenchmark<IntegerRing>/arb_Z/1/1/1                        2327 ns     1143 ns
ElementBenchmark<IntegerRing>/arb_Z/2/1/0/0/1                    2311 ns     1142 ns
ElementBenchmark<IntegerRing>/arb_Z/2/3/4/1/2                  289431 ns    13043 ns
ElementBenchmark<RationalField>/arb_Q/0                          2543 ns     1349 ns
ElementBenchmark<RationalField>/arb_Q/1/1/1                      2510 ns     1338 ns
ElementBenchmark<RationalField>/arb_Q/2/1/0/0/1                  2543 ns     1321 ns
ElementBenchmark<RationalField>/arb_Q/2/3/4/1/2                286573 ns    13563 ns
ElementBenchmark<NumberField>/arb_K/0                            2594 ns     1422 ns
ElementBenchmark<NumberField>/arb_K/1/1/1                        2583 ns     1424 ns
ElementBenchmark<NumberField>/arb_K/2/1/0/0/1                    2561 ns     1432 ns
ElementBenchmark<NumberField>/arb_K/2/3/4/1/2                  113436 ns     6106 ns
```