### PR TITLE
Speedup Element::floordiv

### DIFF
--- a/news/floordiv.rst
+++ b/news/floordiv.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* speed up floor division


### PR DESCRIPTION
Here are some before and after comparisons.
```
    ElementBenchmark<IntegerRing>/floordiv_Z/0                  12084 ns    618 ns
    ElementBenchmark<IntegerRing>/floordiv_Z/1/1/1              12079 ns    618 ns
    ElementBenchmark<IntegerRing>/floordiv_Z/2/1/0/0/1          16664 ns   1062 ns
    ElementBenchmark<IntegerRing>/floordiv_Z/2/3/4/1/2         199936 ns  35129 ns
    ElementBenchmark<RationalField>/floordiv_Q/0                15819 ns   1587 ns
    ElementBenchmark<RationalField>/floordiv_Q/1/1/1            15932 ns   1589 ns
    ElementBenchmark<RationalField>/floordiv_Q/2/1/0/0/1        24474 ns   3063 ns
    ElementBenchmark<RationalField>/floordiv_Q/2/3/4/1/2       343992 ns  44042 ns
    ElementBenchmark<NumberField>/floordiv_K/0                  12864 ns    928 ns
    ElementBenchmark<NumberField>/floordiv_K/1/1/1              12926 ns    945 ns
    ElementBenchmark<NumberField>/floordiv_K/2/1/0/0/1          16809 ns   1640 ns
    ElementBenchmark<NumberField>/floordiv_K/2/3/4/1/2         184111 ns  40333 ns
```