### PR TITLE
do not publish with each push to master

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,6 +1,6 @@
 name: Publish to Anaconda
 on:
-  push: { branches: [ "master" ] }
+  push: { tags: [ "*" ] }
   pull_request: { branches: [ "master" ] }
 
 concurrency:


### PR DESCRIPTION
but only with pushes to tags.

We thought that having a fixed build number would prevent pushes to
anaconda between release if we do not actually bump that number. But
what actually happens is that changes in dependencies influence the
build string which then leads to pushes. This is confusing because we
end up with packages with the wrong version number.

We could fix the build string also but then we would have to implement
the logic that is enabled by conda_build_config.yaml ourselves.

It would probably have been nice to compute the build_number from the
git history but it turned out to be unreliable to do that in the past.

Since we are release with almost every push to master anyway, this
should not make much of a difference in practice and is what we are
doing for e-antic already anyway.